### PR TITLE
Add docx endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You may need to change the IP depending on how docker is set up on your machine.
 
 #### Rest API description
 
-There is only one **POST** end-point: **/docx/pdf**
+There are two **POST** end-points: **/docx** (returns docx file) and **/docx/pdf** (returns PDF file)
 that accepts JSON data in format:
 
     {
@@ -66,7 +66,7 @@ In return we get also JSON:
 
     {
       status: 'ok',
-      file: '...PDF file encoded with Base64...'
+      file: '...PDF or DOCX file encoded with Base64...'
     }
 
 ##### Example

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You may need to change the IP depending on how docker is set up on your machine.
 
 #### Rest API description
 
-There are two **POST** end-points: **/docx** (returns docx file) and **/docx/pdf** (returns PDF file)
+There are two **POST** end-points: **/docx/docx** (returns docx file) and **/docx/pdf** (returns PDF file)
 that accepts JSON data in format:
 
     {

--- a/server.js
+++ b/server.js
@@ -23,7 +23,7 @@ function createReportPromise(req) {
   });
 }
 
-app.post('/docx', (req, res) => {
+app.post('/docx/docx', (req, res) => {
   createReportPromise(req)
   .then(buffer => {
     res.json({


### PR DESCRIPTION
This adds a new /docx endpoint which will just return the rendered doxc file instead of also converting to PDF as we needed this functionality in some situations where the final docx needed manual adjustments before converting to PDF.

Please reject if this is out of scope for your project.